### PR TITLE
rqrcode version fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'active_model_otp'
 gem 'rotp', '~> 3.3.0'
-gem 'rqrcode'
+gem 'rqrcode', '~> 0.10.1'
 
 group :test do
   gem 'vcr'


### PR DESCRIPTION
redmine_2fa is not compatible with rqrcode >= 1.0

This PR locks `rqrcode` on `~> 0.10.1`